### PR TITLE
fix: exit with correct status code

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "node": ">=18"
   },
   "devDependencies": {
+    "@types/node": "18.11.18",
     "typescript": "^4.9.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@types/node': 18.11.18
   htmlparser2: ^8.0.1
   typescript: ^4.9.4
 
@@ -8,9 +9,14 @@ dependencies:
   htmlparser2: 8.0.1
 
 devDependencies:
+  '@types/node': 18.11.18
   typescript: 4.9.4
 
 packages:
+
+  /@types/node/18.11.18:
+    resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
+    dev: true
 
   /dom-serializer/2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -8,10 +8,12 @@ if (str == null) {
 }
 const initUrl = new URL(str);
 const results = new Map<string, AwakenResult>();
+let isSuccessful = true;
 const onAwaken = ({ status, url, referer, msg }: AwakenResult) => {
   if (200 <= status && status <= 299) {
     console.log(`✅ ${url}`);
   } else {
+    isSuccessful = false;
     console.log(`❌ ${url} (status: ${msg ?? status}, referer: ${referer})`);
   }
 }
@@ -20,4 +22,7 @@ await awaken({ url: initUrl, onAwaken, results });
 const end = Date.now();
 const seconds = (end - start) / 1000;
 console.log(`Done! Awakened ${results.size} links in ${seconds} seconds`);
-process.exit(0); // TODO: should this exit with 1 if there were errors?
+
+if (!isSuccessful) {
+  process.exitCode = 1;
+}

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 import { awaken, AwakenResult } from './index.js';
 
-// @ts-ignore
-const process = globalThis.process;
 const str = process.argv[2];
+if (str == null) {
+  console.error('Usage: links-awakening <url>');
+  process.exit(1);
+}
 const initUrl = new URL(str);
 const results = new Map<string, AwakenResult>();
 const onAwaken = ({ status, url, referer, msg }: AwakenResult) => {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2,7 +2,7 @@
 import { awaken, AwakenResult } from './index.js';
 
 const str = process.argv[2];
-if (str == null) {
+if (!str) {
   console.error('Usage: links-awakening <url>');
   process.exit(1);
 }
@@ -23,6 +23,4 @@ const end = Date.now();
 const seconds = (end - start) / 1000;
 console.log(`Done! Awakened ${results.size} links in ${seconds} seconds`);
 
-if (!isSuccessful) {
-  process.exitCode = 1;
-}
+process.exit(isSuccessful ? 0 : 1);

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import child_process from 'node:child_process';
+
+test('cli example', () => {
+  try {
+    child_process.execSync('node ./dist/bin.js https://example.vercel.sh');
+  } catch {
+    assert.fail('All links should be reachable.');
+  }
+});


### PR DESCRIPTION
Fixes #7

Notes:
- Added `@types/node` dev dependencies to improve type safety, notably for `process` for example, and also verifying that the user gives a URL as third argument. It can be out of scope of this PR, so feel free to tell me if you want to add that in a separated PR.
- Added a new test case in `test/cli-test.js`, but it only has the "happy-path" scenario where all links are valid. I'm not sure what website, we could take for the test, to verify that it exits with status code 1 if there are broken links.
- ESLint, Prettier and editorconfig are not configured on the project, I tried to follow the project conventions with the code already available, forgive me if I forgot a `;` or semicolon or something. :sweat_smile: However, it could be great to integrate these tools to improve consistency (could be done in a separate PR).